### PR TITLE
:sparkles: Introducing UberTC 6.x (gcc 6.4.1).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -622,7 +622,11 @@ KBUILD_CFLAGS	+= $(call cc-disable-warning, int-in-bool-context)
 KBUILD_CFLAGS	+= $(call cc-option,-fno-PIE)
 KBUILD_AFLAGS	+= $(call cc-option,-fno-PIE)
 
-ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
+#Custom performance optimization flags
+ifneq ($(KBUILD_LOUP_CFLAGS),)
+$(info Using custom flags!!! [${KBUILD_LOUP_CFLAGS}])
+KBUILD_CFLAGS   += $(KBUILD_LOUP_CFLAGS) $(call cc-disable-warning,maybe-uninitialized,)
+else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
 KBUILD_CFLAGS	+= -Os $(call cc-disable-warning,maybe-uninitialized,)
 else
 KBUILD_CFLAGS	+= -O2

--- a/build.sh
+++ b/build.sh
@@ -1,28 +1,27 @@
 #!/bin/bash
-echo "WAFF WAFF WAFF WAFF WAFF WAFF WAFF WAFF"
-echo "########### LOBO UTILIDADES ###########"
-echo "WAFF WAFF WAFF WAFF WAFF WAFF WAFF WAFF"
+echo "#########################################"
+echo "##### LOUP Kernel - Build Script ########"
+echo "#########################################"
 echo ""
-#echo "> Copiando archivo de configuracion"
-#cp ../boot_miui_official/msm8940_defconfig .config
-#echo "> Copiando ramdisk a arch/arm64/boot"
-#cp ../generated_boot_img/initramfs.cpio.gz arch/arm64/boot/boot.img-ramdisk.cpio.gz
-echo "> Abriendo archivo de configuracion"
-CFLAGS="-mtune=cortex-a53 -march=armv8-a -mcpu=cortex-a53 -O2" ARCH=arm64 CROSS_COMPILE=../aarch64-linux-android-4.9/bin/aarch64-linux-android- make menuconfig
-echo "> Iniciando compilacion del kernel usando .config"
-CFLAGS="-mtune=cortex-a53 -march=armv8-a -mcpu=cortex-a53 -O2" ARCH=arm64 CROSS_COMPILE=../aarch64-linux-android-4.9/bin/aarch64-linux-android- make -j4
-echo ""
-#echo "> Eliminando boot.img viejo"
-#rm arch/arm64/boot/boot.img
-#echo "> EMPAQUETANDO Kernel..."
-#./../mkbootimg/mkbootimg --kernel arch/arm64/boot/Image.gz-dtb --ramdisk arch/arm64/boot/boot.img-ramdisk.cpio.gz --cmdline 'console=ttyHSL0,115200,n8 androidboot.console=ttyHSL0 androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78B0000 buildvariant=eng androidboot.selinux=permissive enforcing=0' --base 0x80000000 -o arch/arm64/boot/boot.img
-#echo "> ELIMINANDO MODULOS ANTERIORES"
-#rm -rf /media/psf/Home/Desktop/kmodules
-#mkdir /media/psf/Home/Desktop/kmodules
-#echo "> COPIANDO MODULOS A /media/psf/Home/Desktop/kmodules"
-#find . -type f -name "*.ko" -exec cp -fv {} /media/psf/Home/Desktop/kmodules/. \;
-#echo "> COPIANDO boot.img a /media/psf/Home/Desktop/"
-#cp arch/arm64/boot/boot.img /media/psf/Home/Desktop/.
+echo "> Opening .config file..."
 
+# Want to use a different toolchain? (Linaro, UberTC, etc)
+# ==================================
+# point CROSS_COMPILE to the folder of the desired toolchain
+# don't forget to specify the prefix. Mine is: aarch64-linux-android-
+ARCH=arm64 SUBARCH=arm64 CROSS_COMPILE=../aarch64-linux-android-6.x/bin/aarch64-linux-android- make menuconfig
+
+echo "> Starting kernel compilation using .config file..."
+# Want custom kernel flags?
+# =========================
+# KBUILD_LOUP_CFLAGS: Here you can set custom compilation 
+# flags to turn off unwanted warnings, or even set a 
+# different optimization level. 
+# To see how it works, check the Makefile ... file, 
+# line 625 to 628, located in the root dir of this kernel.
+KBUILD_LOUP_CFLAGS="-Wno-misleading-indentation -Wno-bool-compare -mtune=cortex-a53 -march=armv8-a+crc+simd+crypto -mcpu=cortex-a53 -O2" ARCH=arm64 SUBARCH=arm64 CROSS_COMPILE=../aarch64-linux-android-6.x/bin/aarch64-linux-android- make -j5
+echo ""
+
+# Pack the kernel as a flashable TWRP zip.
 ./../AnyKernel2/build.sh
-echo "WAAAAAAAF IS DONE"
+echo "DONE!"

--- a/drivers/staging/prima/CORE/VOSS/src/wlan_nv_template_builtin.c
+++ b/drivers/staging/prima/CORE/VOSS/src/wlan_nv_template_builtin.c
@@ -587,8 +587,8 @@ _NV_TEMPLATE_TABLE NvTablesBuiltIn[/*TABLES_MAX*/][TABLE_ENTRIES_MAX] = {
          ((char *)&(nvDefaults.tables.hwCalValues.calData.psSlpTimeOvrHdxLNA5G) -
           (char *)&nvDefaults.tables.hwCalValues.calData),"psSlpTimeOvrHdxLNA5G"},
       {"ed",_ID_U8,SINGULAR,0,0,0,
-         (((char *)&(nvDefaults.tables.hwCalValues.calData.psSlpTimeOvrHdxLNA5G) +
-          sizeof(uint16)) - (char *)&nvDefaults.tables.hwCalValues.calData),
+         (((char *)&(nvDefaults.tables.hwCalValues.calData.psSlpTimeOvrHdxLNA5G) /*+
+          sizeof(uint16)*/) - (char *)&nvDefaults.tables.hwCalValues.calData),
          "nv_TxBBFSel9MHz"},
       {"ee",_ID_U8,SINGULAR,0,0,0,
          ((char *)&(nvDefaults.tables.hwCalValues.calData.hwParam2) -


### PR DESCRIPTION
  - Updated build script, now points to UberTC 6.x toolchain. Now in English :P
  - Updated root Makefile to support custom compilation flags.
  - Included -O2 optimization level, and [crc simd crypto] extensions.
  - :bug: prima: [HACK] Fixed "Error: initializer element is not computable at load time" by commenting out sizeof calculation. (It seems we're not using that element).

TODO (We can ignore them for now):
  - Fix -Wmisleading-indentation
  - Fix -Wbool-compare