### PR TITLE
touchscreen: ft5x06: defer resume function to workqueue

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8937-pmi8950-qrd-sku1.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8937-pmi8950-qrd-sku1.dtsi
@@ -83,6 +83,7 @@
 			focaltech,fw-delay-era-flsh-ms = <2000>;
 			focaltech,fw-auto-cal;
 			focaltech,ignore-id-check;
+			focaltech,resume-in-workqueue;
 		};
 		synaptics@4b {
 			/*compatible = "synaptics,dsx";


### PR DESCRIPTION
This will help reduce delay on wakeup (screen on).

The 'resume_in_workqueue' variable in ft5x06 is set to false by default
and need flag 'focaltech,resume-in-workqueue' to enabling it. Add flag
'focaltech,resume-in-workqueue' to defer resume function to workqueue
instead of direct call the suspend/resume function.

Signed-off-by: Ryan Andri <ryanandri@linuxmail.org>